### PR TITLE
Feat/add default context and domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,11 +141,11 @@ defmodule MyApp.Repo.Migrations.AddKantaTranslationsTable do
   use Ecto.Migration
 
   def up do
-    Kanta.Migration.up(version: 2, prefix: prefix()) # Prefix is needed if you are using multitenancy with i.e. triplex
+    Kanta.Migration.up(version: 3, prefix: prefix()) # Prefix is needed if you are using multitenancy with i.e. triplex
   end
 
   def down do
-    Kanta.Migration.down(version: 2, prefix: prefix()) # Prefix is needed if you are using multitenancy with i.e. triplex
+    Kanta.Migration.down(version: 3, prefix: prefix()) # Prefix is needed if you are using multitenancy with i.e. triplex
   end
 end
 ```

--- a/lib/kanta/migrations/postgresql/v03.ex
+++ b/lib/kanta/migrations/postgresql/v03.ex
@@ -1,0 +1,27 @@
+defmodule Kanta.Migrations.Postgresql.V03 do
+  @moduledoc """
+  Kanta V3 Migrations
+  """
+
+  use Ecto.Migration
+  alias Kanta.Translations
+  alias Kanta.Translations.Context
+
+  @default_prefix "public"
+  @kanta_singular_translations "kanta_singular_translations"
+  @kanta_plural_translations "kanta_plural_translations"
+
+  def up(opts) do
+    Kanta.Migration.up(version: 2)
+
+    execute(
+      "INSERT INTO kanta_contexts (name,inserted_at,updated_at) VALUES('default', NOW(), NOW()) ON CONFLICT (name) DO NOTHING;"
+    )
+
+    execute("UPDATE kanta_messages SET context_id=1 WHERE context_id IS NULL;")
+  end
+
+  def down(opts) do
+    Kanta.Migration.down(version: 2)
+  end
+end

--- a/lib/kanta/po_files/handlers/messages_extractor.ex
+++ b/lib/kanta/po_files/handlers/messages_extractor.ex
@@ -4,6 +4,7 @@ defmodule Kanta.POFiles.MessagesExtractor do
   """
 
   @po_wildcard "**/*.po"
+  @default_context "default"
 
   alias Expo.{Messages, PO}
 
@@ -38,6 +39,7 @@ defmodule Kanta.POFiles.MessagesExtractor do
       %Expo.Message.Singular{msgctxt: nil, msgid: [msgid], msgstr: texts} ->
         ExtractSingularTranslation.call(%{
           msgid: msgid,
+          context_name: @default_context,
           locale_name: locale,
           domain_name: domain,
           original_text: Enum.join(texts)
@@ -55,6 +57,7 @@ defmodule Kanta.POFiles.MessagesExtractor do
       %Expo.Message.Plural{msgctxt: nil, msgid_plural: [msgid], msgstr: plurals_map} ->
         ExtractPluralTranslation.call(%{
           msgid: msgid,
+          context_name: @default_context,
           locale_name: locale,
           domain_name: domain,
           plurals_map: plurals_map,

--- a/lib/kanta/po_files/services/extract_message.ex
+++ b/lib/kanta/po_files/services/extract_message.ex
@@ -8,6 +8,9 @@ defmodule Kanta.PoFiles.Services.ExtractMessage do
   alias Kanta.Translations
   alias Kanta.Translations.{Context, Domain}
 
+  @default_domain "default"
+  @default_context "default"
+
   def call(attrs) do
     Repo.get_repo().transaction(fn ->
       with {:ok, domain} <- assign_domain(attrs[:domain_name]),
@@ -48,6 +51,7 @@ defmodule Kanta.PoFiles.Services.ExtractMessage do
       {:error, :message, :not_found} ->
         attrs
         |> Map.put(:context_id, context_id)
+        |> Map.put(:domain_id, @default_domain)
         |> Translations.create_message()
     end
   end
@@ -59,6 +63,7 @@ defmodule Kanta.PoFiles.Services.ExtractMessage do
 
       {:error, :message, :not_found} ->
         attrs
+        |> Map.put(:context_id, @default_context)
         |> Map.put(:domain_id, domain_id)
         |> Translations.create_message()
     end


### PR DESCRIPTION
# Background 

Last time we've added UNIQUE constraint for kanta, for prevents duplicate entrty.
https://3.basecamp.com/5773253/buckets/36965478/card_tables/cards/7519531566#__recording_7562390811

but applying multiple constraints causes performance down (and it might causes unexpected behaviours), hence in this PR I added logic to register `default` context if it's unspecified in po files.

You can test from here: https://nexus-staging-2216d6ee.fly.dev/kanta/dashboard

# FYI

This feature is already approved in origin, but not merged yet.

https://github.com/curiosum-dev/kanta/pull/69 